### PR TITLE
Minor punctuation and some more details

### DIFF
--- a/01-Scientific Computing/01-Scientific Computing.ipynb
+++ b/01-Scientific Computing/01-Scientific Computing.ipynb
@@ -1131,14 +1131,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0270f48d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
    "execution_count": 38,
    "id": "16467aec-adca-41a0-8d01-f366156e3cac",
    "metadata": {},

--- a/01-Scientific Computing/01-Scientific Computing.ipynb
+++ b/01-Scientific Computing/01-Scientific Computing.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "In this tutorial we will look at some important basic aspects of scientific computing with Python. Before we start, let's look at some useful tricks in Python.\n",
     "\n",
-    "When printing data, it's convenient to use **formatted strings**. A formatted string starts with an `f` and you can reference variables in it by surrounding them with braces (`{}`). Here are some examples of formatted strings used in printing"
+    "When printing data, it's convenient to use **formatted strings**. A formatted string starts with an `f` and you can reference variables in it by surrounding them with braces (`{}`). Here are some examples of formatted strings used in printing:"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "\n",
     "Python can stored both integers and floating-point numbers. These two types work differently. Integers are stored with exact precision. This means that if we make an arbitrarily large integer, we can represent any operation on it without loosing accuracy.\n",
     "\n",
-    "Let's create the integer $10^{99}$"
+    "Let's create the integer $10^{99}$:"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "id": "367b9e7c-d764-4541-a29b-90fa4e991e6d",
    "metadata": {},
    "source": [
-    "we can add 1 to $n$ and represent the result exactly (here we use formatted strings, to conveniently print variables and text)"
+    "We can add 1 to $n$ and represent the result exactly (here, we use formatted strings, to conveniently print variables and text):"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "id": "909c04d3-eaa4-44c0-b196-53d8f5bb5149",
    "metadata": {},
    "source": [
-    "We can correctly compute the difference of $m$ and $n$ and and the two numbers are not equal (which we test with `==`)"
+    "We can correctly compute the difference of $m$ and $n$ and and the two numbers are not equal (which we test with `==`):"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "id": "6695f757-71d2-4765-a0c9-248c1dc51713",
    "metadata": {},
    "source": [
-    "Floating-point numbers are represented instead using a binary fraction and have limited precision. For example, this sum does not evaluate to what you would expect"
+    "Floating-point numbers are represented instead using a binary fraction and have limited precision. For example, this sum does not evaluate to what you would expect:"
    ]
   },
   {
@@ -193,7 +193,7 @@
    "id": "b9a4259e-2215-43c8-944c-03fd7bcf40b2",
    "metadata": {},
    "source": [
-    "For double-precision floating-point numbers, you should expect numbers to be represented with a relative accuracy of about $10^{-15}$. Here if we add one to the number $x = 10^{15}$ we retain enough precision to correctly evaluate the difference $(10^{15} + 1) - (10^{15})$"
+    "For double-precision floating-point numbers, you should expect numbers to be represented with a relative accuracy of about $10^{-15}$. Here, if we add one to the number $x = 10^{15}$, we retain enough precision to correctly evaluate the difference $(10^{15} + 1) - (10^{15})$:"
    ]
   },
   {
@@ -223,7 +223,7 @@
    "id": "76e7df11-0e32-4dad-b36f-feb4c5bbf74f",
    "metadata": {},
    "source": [
-    "However, if we set $x = 10^{16}$ subtracting the two numbers gives zero and Python thinks the two numbers are the *same*"
+    "However, if we set $x = 10^{16}$, subtracting the two numbers gives zero and Python thinks the two numbers are the *same*:"
    ]
   },
   {
@@ -269,7 +269,7 @@
    "id": "c81787c5-6c0c-4b37-ab0c-a6187987349a",
    "metadata": {},
    "source": [
-    "In Python you can represent vectors using lists. Elements of a vector can be accessed and modified"
+    "In Python you can represent vectors using lists. Elements of a vector can be accessed and modified:"
    ]
   },
   {
@@ -306,7 +306,7 @@
     "- **Complexity**. Expressing many mathematical operations on vectors, matrices, and tensors can require writing several lines of Python.\n",
     "- **Potential for errors**. The more code you have to write, the more likely it will contain errors in it.\n",
     "\n",
-    "A better solution is to use a library that specializes in manipulating arbitrary-order tensors, like `numpy`. Let's import numpy and look at how we can store vectors with it"
+    "A better solution is to use a library that specializes in manipulating arbitrary-order tensors, like `numpy`. Let's import numpy and look at how we can store vectors with it:"
    ]
   },
   {
@@ -324,7 +324,7 @@
    "id": "22e0916a-20b6-42a7-b633-a062b49507cd",
    "metadata": {},
    "source": [
-    "To create a vector from a list of values, we can call the `array` function"
+    "To create a vector from a list of values, we can call the `array` function:"
    ]
   },
   {
@@ -351,7 +351,7 @@
    "id": "4e64ec3a-3c9a-4d76-9304-e574c8e90afd",
    "metadata": {},
    "source": [
-    "An alternative approach is creating a vector and then populating it with values. Here we create a vector with 10 entries initialized to zero and set the fourth entry (with index equal to 3) to 5"
+    "An alternative approach is creating a vector and then populating it with values. Here, we create a vector with 10 entries initialized to zero and set the fourth entry (with index equal to 3) to 5. Python arrays are 0-indexed, meaning that the first element has index 0, the second has index 1, and so on, so forth. "
    ]
   },
   {
@@ -381,7 +381,7 @@
    "source": [
     "Notice that `numpy` refers to vectors, matrices, and tensors with the generic term array.\n",
     "    \n",
-    "Let's create two lists and numpy arrays fill them with the numbers $0, 1, \\ldots, N - 1$, where $N = 10^{6}$"
+    "Let's create two lists and numpy arrays fill them with the numbers $0, 1, \\ldots, N - 1$, where $N = 10^{6}$:"
    ]
   },
   {
@@ -408,7 +408,7 @@
    "metadata": {},
    "source": [
     "Next, let's add up the two vectors ($\\mathbf{a} + \\mathbf{b}$) stored as a list and compute their dot product ($\\mathbf{a} \\cdot \\mathbf{b}$).\n",
-    "We will surround these instructions with calls to `perf_counter()` to get the total timing for these operations"
+    "We will surround these instructions with calls to `perf_counter()` to get the total timing for these operations:"
    ]
   },
   {
@@ -449,7 +449,7 @@
    "id": "7fb0fef6-745d-48b7-a6e4-218c70418669",
    "metadata": {},
    "source": [
-    "Now, we repeat the same operations using `numpy`"
+    "Now, we repeat the same operations using `numpy`:"
    ]
   },
   {
@@ -487,7 +487,7 @@
    "id": "7d2c2499-99d0-4c0c-87fe-02838d2fcfbd",
    "metadata": {},
    "source": [
-    "Finally, we can compute the speedup achieved by numpy compared to the naïve Python implementation"
+    "Finally, we can compute the speedup achieved by numpy compared to the naïve Python implementation:"
    ]
   },
   {
@@ -526,7 +526,7 @@
    "source": [
     "## The basics of NumPy\n",
     "\n",
-    "Let's explore some basic features of numpy. Arrays are characterized by the number of axes (also called rank), the range of values each index can take, and the type of data it stores. Creating a matrix (an array with two axes/indices) of dimensions $3 \\times 7$ with all zero entries can be done by passing a shape in the form of a tuple"
+    "Let's explore some basic features of numpy. Arrays are characterized by the number of axes (also called rank), the range of values each index can take, and the type of data it stores. Creating a matrix (an array with two axes/indices) of dimensions $3 \\times 7$ with all zero entries can be done by passing a shape in the form of a tuple:"
    ]
   },
   {
@@ -597,7 +597,7 @@
     "\n",
     "Filling an array with zeros requires paying a small overhead for setting all the values to 0, but it is good practice since we could have bugs if we allocate an array and only set a fraction of the entries, assuming the rest should be zero.\n",
     "\n",
-    "Here are two other ways to initialize arrays"
+    "Here are two other ways to initialize arrays:"
    ]
   },
   {
@@ -653,7 +653,7 @@
    "id": "78b3f01f",
    "metadata": {},
    "source": [
-    "For small matrices and tensors, you can also create an array by passing the values using list of lists"
+    "For small matrices and tensors, you can also create an array by passing the values using list of lists:"
    ]
   },
   {
@@ -683,7 +683,7 @@
    "id": "b330f70b-297a-4dde-a159-abc41d2529b1",
    "metadata": {},
    "source": [
-    "We can access elements of an array by indexing the array"
+    "We can access elements of an array by indexing the array:"
    ]
   },
   {
@@ -713,7 +713,7 @@
    "id": "f555be87-6af3-495a-b4aa-91b195c2143d",
    "metadata": {},
    "source": [
-    "Once we have stored data in arrays, there are many operations we can easily perform with numpy. If there is a function in numpy that will do what you need, as a general rule, use it instead of writing Python code. You are certainly guaranteed that it will be faster and correct. Here are some examples"
+    "Once we have stored data in arrays, there are many operations we can easily perform with numpy. If there is a function in numpy that will do what you need, as a general rule, use it instead of writing Python code. You are certainly guaranteed that it will be faster and correct. Here are some examples:"
    ]
   },
   {
@@ -810,7 +810,7 @@
    "source": [
     "## Slicing arrays\n",
     "\n",
-    "Often it is necessary to access parts of an array. Slicing offers a convenient way to do so without actually copying the data. Slicing follows the same format as accessing an element of an array but instead of a number we pass the beginning and the end (non inclusive) indices of the array. In this example, we get a slice from the second to the fourth element of the array `v`"
+    "Often it is necessary to access parts of an array. Slicing offers a convenient way to do so without actually copying the data. Slicing follows the same format as accessing an element of an array but instead of a number, we pass the beginning and the end (non inclusive) indices of the array. In this example, we get a slice from the second to the fourth element of the array `v`:"
    ]
   },
   {
@@ -883,7 +883,7 @@
    "id": "6f83d23b-41ac-45e9-abad-57114a361d7b",
    "metadata": {},
    "source": [
-    "We can also create slices that skip over data"
+    "We can also create slices that skip over data by specifying a starting point, ending point (non-inclusive), and a 'step' value:"
    ]
   },
   {
@@ -913,7 +913,7 @@
    "id": "2a8f68dc-4874-43b6-a658-df2366f8f133",
    "metadata": {},
    "source": [
-    "For matrices and tensors, we can also specify all the elements in an index with `:`. The following code grabs the first column of the matrix $M$"
+    "For matrices and tensors, we can also specify all the elements in an index with `:`. The following code grabs the first column of the matrix $M$:"
    ]
   },
   {
@@ -958,7 +958,7 @@
     "```python\n",
     "n = [10, 20]\n",
     "```\n",
-    "we should think of this as *the variable* `n` *is pointing to the list* `[10, 20]`. It is a good idea to become familiar with this concept because it has important consequence when we write code. Consider the following example"
+    "we should think of this as *the variable* `n` *is pointing to the list* `[10, 20]`. It is a good idea to become familiar with this concept because it has important consequence when we write code. Consider the following example:"
    ]
   },
   {
@@ -983,7 +983,7 @@
    "id": "9b81915c-2e1b-4557-9be0-8b5214853f05",
    "metadata": {},
    "source": [
-    "What do you expect the arrays `x` and `y` to look like after this code is executed? Let's check 🔍"
+    "What do you expect the arrays `x` and `y` to look like after this code is executed? Let's check 🔍:"
    ]
   },
   {
@@ -1011,7 +1011,7 @@
    "id": "a01401f2-e025-46a3-b505-9931f641e2a8",
    "metadata": {},
    "source": [
-    "The two arrays show the same change, and that's because both `x` and `y` are variables that point to the **same underlying data**. If we want to copy the data of an array we can call the `copy()` method"
+    "The two arrays show the same change, and that's because both `x` and `y` are variables that point to the **same underlying data**. If we want to copy the data of an array we can call the `copy()` method:"
    ]
   },
   {
@@ -1045,7 +1045,7 @@
    "source": [
     "## Plotting data\n",
     "\n",
-    "We will often want to visualize data contained in arrays. We can do this with the library `matplotlib`. The next two examples demonstrate plotting a vector and a matrix"
+    "We will often want to visualize data contained in arrays. We can do this with the library `matplotlib`. The next two examples demonstrate plotting a vector and a matrix:"
    ]
   },
   {
@@ -1131,6 +1131,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "0270f48d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": 38,
    "id": "16467aec-adca-41a0-8d01-f366156e3cac",
    "metadata": {},
@@ -1159,6 +1167,30 @@
     "# print up to three decimals\n",
     "with np.printoptions(precision=3, suppress=True):\n",
     "    print(f'\\nPretty printing\\n{A}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be65d1ba",
+   "metadata": {},
+   "source": [
+    "## Useful NumPy functions\n",
+    "\n",
+    "You can find documentation for NumPy functions at https://numpy.org/doc/. NumPy can carry out much of the linear algebra necessary for quantum chemistry. Here is a list of some helpful functions: \n",
+    "\n",
+    "- `linalg.norm(x, ord=None, axis=None, keepdims=False)`: returns matrix or vector norm\n",
+    "\n",
+    "- `einsum(subscripts, *operands, out=None, dtype=None, order='K', casting='safe', optimize=False)`: evaluates Einstein summation on the operands\n",
+    "\n",
+    "- `linalg.eigh(a, UPLO='L')`: returns the eigenvalues and eigenvectors of complex Hermitian or real symmetrix matrix in a tuple with two arrays, with the first containing the eigenvalues in ascending order and the second containing the corresponding eigenvectors\n",
+    "\n",
+    "- `linalg.eigvalsh(a, UPLO='L')`: returns the eigenvalues of complex Hermitian or real symmetric matrix in ascending order in an array\n",
+    "\n",
+    "Familiarizing yourself with NumPy's linear algebra functions will make the following tutorials much easier!\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
Standardized punctuation + minor fixes, mentioned NumPy 0-indexing earlier. Added short list of NumPy linear algebra functions at the end for user reference (should most likely be expanded if you decide to keep it). This list could be framed within the context of the 00 tutorial. 